### PR TITLE
use our own dockerconfigresolver from nerdctl v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,16 @@ module github.com/AkihiroSuda/apt-transport-oci
 go 1.16
 
 require (
-	github.com/cloudflare/apt-transport-cloudflared v0.0.0-20190717195953-96e1417f9c54
+	github.com/cloudflare/apt-transport-cloudflared v0.0.0-20210629160405-bbcb96fd4852
 	github.com/containerd/containerd v1.5.2
-	github.com/containerd/nerdctl v0.9.0
+	github.com/docker/cli v20.10.7+incompatible
+	github.com/docker/docker v20.10.7+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.7.0
 )
-
-// https://github.com/cloudflare/apt-transport-cloudflared/pull/1
-replace github.com/cloudflare/apt-transport-cloudflared => github.com/AkihiroSuda/apt-transport-cloudflared v0.0.0-20210629160405-bbcb96fd4852
 
 // LICENSE:
 // - cloudflare/apt-transport-cloudflared: BSD 3-clause https://github.com/cloudflare/apt-transport-cloudflared/blob/96e1417f9c542a53d41b619cd17d3ccd9786fd49/LICENSE

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/apt-transport-cloudflared v0.0.0-20210629160405-bbcb96fd4852 h1:Tj1hREyzyINkp6dAgpfrQOlNKkreCx0scj0encjxNdQ=
+github.com/cloudflare/apt-transport-cloudflared v0.0.0-20210629160405-bbcb96fd4852/go.mod h1:yPnO5LOKukkQWH4iPAtHpU6hjmYkTas+GpXq+44N2C0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -211,6 +213,7 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -231,6 +234,8 @@ github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYS
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
+github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
+github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -411,6 +416,7 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
@@ -566,6 +572,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -741,6 +748,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -810,6 +818,7 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -922,6 +931,7 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=

--- a/pkg/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/dockerconfigresolver/dockerconfigresolver.go
@@ -1,0 +1,187 @@
+/*
+   Copyright The containerd Authors.
+
+   Original source: https://github.com/containerd/nerdctl/blob/v0.9.0/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+   We copy the source from upstream nerdctl v0.9.0 for easier packageing
+   on debian system. We can delete this file and add upstream nerdctl
+   back when:
+   1, nerdctl is packaged in debian
+   2, apt-transport-oci can use the packaged nerdctl in debian
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dockerconfigresolver
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	dockercliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/credentials"
+	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type opts struct {
+	plainHTTP       bool
+	skipVerifyCerts bool
+}
+
+// Opt for New
+type Opt func(*opts)
+
+// WithPlainHTTP enables insecure plain HTTP
+func WithPlainHTTP(b bool) Opt {
+	return func(o *opts) {
+		o.plainHTTP = b
+	}
+}
+
+// WithSkipVerifyCerts skips verifying TLS certs
+func WithSkipVerifyCerts(b bool) Opt {
+	return func(o *opts) {
+		o.skipVerifyCerts = b
+	}
+}
+
+// New instantiates a resolver using $DOCKER_CONFIG/config.json .
+//
+// $DOCKER_CONFIG defaults to "~/.docker".
+//
+// refHostname is like "docker.io".
+func New(refHostname string, optFuncs ...Opt) (remotes.Resolver, error) {
+	var o opts
+	for _, of := range optFuncs {
+		of(&o)
+	}
+	var authzOpts []docker.AuthorizerOpt
+	if authCreds, err := NewAuthCreds(refHostname); err != nil {
+		return nil, err
+	} else {
+		authzOpts = append(authzOpts, docker.WithAuthCreds(authCreds))
+	}
+	authz := docker.NewDockerAuthorizer(authzOpts...)
+	plainHTTPFunc := docker.MatchLocalhost
+	if o.plainHTTP {
+		plainHTTPFunc = docker.MatchAllHosts
+	}
+	regOpts := []docker.RegistryOpt{
+		docker.WithAuthorizer(authz),
+		docker.WithPlainHTTP(plainHTTPFunc),
+	}
+	if o.skipVerifyCerts {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		client := &http.Client{
+			Transport: tr,
+		}
+		regOpts = append(regOpts, docker.WithClient(client))
+	}
+	resovlerOpts := docker.ResolverOptions{
+		Hosts: docker.ConfigureDefaultRegistries(regOpts...),
+	}
+	resolver := docker.NewResolver(resovlerOpts)
+	return resolver, nil
+}
+
+// AuthCreds is for docker.WithAuthCreds
+type AuthCreds func(string) (string, string, error)
+
+// NewAuthCreds returns AuthCreds that uses $DOCKER_CONFIG/config.json .
+// AuthCreds can be nil.
+func NewAuthCreds(refHostname string) (AuthCreds, error) {
+	// Load does not raise an error on ENOENT
+	dockerConfigFile, err := dockercliconfig.Load("")
+	if err != nil {
+		return nil, err
+	}
+
+	// DefaultHost converts "docker.io" to "registry-1.docker.io",
+	// which is wanted  by credFunc .
+	credFuncExpectedHostname, err := docker.DefaultHost(refHostname)
+	if err != nil {
+		return nil, err
+	}
+
+	var credFunc AuthCreds
+
+	authConfigHostnames := []string{refHostname}
+	if refHostname == "docker.io" || refHostname == "registry-1.docker.io" {
+		// "docker.io" appears as ""https://index.docker.io/v1/" in ~/.docker/config.json .
+		// GetAuthConfig takes the hostname part as the argument: "index.docker.io"
+		authConfigHostnames = append([]string{"index.docker.io"}, refHostname)
+	}
+
+	for _, authConfigHostname := range authConfigHostnames {
+		// GetAuthConfig does not raise an error on ENOENT
+		ac, err := dockerConfigFile.GetAuthConfig(authConfigHostname)
+		if err != nil {
+			logrus.WithError(err).Warnf("cannot get auth config for authConfigHostname=%q (refHostname=%q)",
+				authConfigHostname, refHostname)
+		} else {
+			// When refHostname is "docker.io":
+			// - credFuncExpectedHostname: "registry-1.docker.io"
+			// - credFuncArg:              "registry-1.docker.io"
+			// - authConfigHostname:       "index.docker.io"
+			// - ac.ServerAddress:         "https://index.docker.io/v1/".
+			if !isAuthConfigEmpty(ac) {
+				if ac.ServerAddress == "" {
+					// Can this happen?
+					logrus.Warnf("failed to get ac.ServerAddress for authConfigHostname=%q (refHostname=%q)",
+						authConfigHostname, refHostname)
+				} else {
+					acsaHostname := credentials.ConvertToHostname(ac.ServerAddress)
+					if acsaHostname != authConfigHostname {
+						return nil, errors.Errorf("expected the hostname part of ac.ServerAddress (%q) to be authConfigHostname=%q, got %q",
+							ac.ServerAddress, authConfigHostname, acsaHostname)
+					}
+				}
+
+				if ac.RegistryToken != "" {
+					// Even containerd/CRI does not support RegistryToken as of v1.4.3,
+					// so, nobody is actually using RegistryToken?
+					logrus.Warnf("ac.RegistryToken (for %q) is not supported yet (FIXME)", authConfigHostname)
+				}
+
+				credFunc = func(credFuncArg string) (string, string, error) {
+					// credFuncArg should be like "registry-1.docker.io"
+					if credFuncArg != credFuncExpectedHostname {
+						return "", "", errors.Errorf("expected credFuncExpectedHostname=%q (refHostname=%q), got credFuncArg=%q",
+							credFuncExpectedHostname, refHostname, credFuncArg)
+					}
+					if ac.IdentityToken != "" {
+						return "", ac.IdentityToken, nil
+					}
+					return ac.Username, ac.Password, nil
+				}
+				break
+			}
+		}
+	}
+	// credsFunc can be nil here
+	return credFunc, nil
+}
+
+func isAuthConfigEmpty(ac dockercliconfigtypes.AuthConfig) bool {
+	if ac.IdentityToken != "" || ac.Username != "" || ac.Password != "" || ac.RegistryToken != "" {
+		return false
+	}
+	return true
+}

--- a/pkg/method/method.go
+++ b/pkg/method/method.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containerd/containerd/images"
 	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/nerdctl/pkg/imgutil/dockerconfigresolver"
+	"github.com/AkihiroSuda/apt-transport-oci/pkg/dockerconfigresolver"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )


### PR DESCRIPTION
I'm  going to package for debian and I find that dependency of nerdctl is hard to solve.
- `nerdctl` has been updated to v2.0.0 but we need dockerconfigresolver from  v0.9.0. If debian will package the latest version of nerdctl, not the version from 3 years ago.
- Pacakging nerdctl is hard since there are a lot of its dependencies not packaged in debian.
- The only package we use from nerdctl is dockerconfigresolver.

So moving  dockerconfigresolver to this repo will make porting to debian easier, another depdency `github.com/cloudflare/apt-transport-cloudflared` is easy to package.

I hope someday debian will support oci repo by default, no need to let user build/download oci binary by themself. Just an  apt command can do this. And this is the start work  of it.